### PR TITLE
feat: [backend] 予約管理用被保険者検索バリデーション作成

### DIFF
--- a/backend/controller/insured_controller.go
+++ b/backend/controller/insured_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"backend/model"
 	"backend/usecase"
 	"net/http"
 
@@ -34,11 +35,14 @@ func (ic *insuredController) GetInsureds(c echo.Context) error {
 
 func (ic *insuredController) GetInsuredsWithReservation(c echo.Context) error {
 
-	firstName := c.QueryParam("firstName")
-	lastName := c.QueryParam("lastName")
-	birthday := c.QueryParam("birthday")
+	queryParams := model.InsuredQueryParams{}
 
-	insuredsRes, err := ic.iu.GetInsuredsWithReservation(firstName, lastName, birthday)
+	if err := c.Bind(&queryParams); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+
+	insuredsRes, err := ic.iu.GetInsuredsWithReservation(queryParams)
+
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,9 +19,9 @@ func main() {
 	userController := controller.NewUserController(userUsecase)
 
 	// Insured
-	// insuredValidator := validator.NewInsuredValidator() ok
+	insuredValidator := validator.NewInsuredValidator()
 	insuredRepository := repository.NewInsuredRepository(db)
-	insuredUsecase := usecase.NewInsuredUsecase(insuredRepository)
+	insuredUsecase := usecase.NewInsuredUsecase(insuredRepository, insuredValidator)
 	insuredController := controller.NewInsuredController(insuredUsecase)
 
 	// ReservationSlot

--- a/backend/model/insured.go
+++ b/backend/model/insured.go
@@ -30,6 +30,12 @@ type InsuredResponse struct {
 	Address       string    `json:"address" gorm:"not null"`
 }
 
+type InsuredQueryParams struct {
+	FirstNameKana string `query:"first_name_kana"`
+	LastNameKana  string `query:"last_name_kana"`
+	Birthday      string `query:"birthday"`
+}
+
 type InsuredWithReservationResponse struct {
 	ID               uint      `json:"id" gorm:"primaryKey"`
 	Number           uint      `json:"number" gorm:"not null"`

--- a/backend/repository/insured_repository.go
+++ b/backend/repository/insured_repository.go
@@ -8,7 +8,7 @@ import (
 
 type IInsuredRepository interface {
 	GetInsureds(insureds *[]model.Insured, birthday string) error
-	GetInsuredsWithReservation(insureds *[]model.Insured, firstName, lastName, birthday string) error
+	GetInsuredsWithReservation(insureds *[]model.Insured, queryParams *model.InsuredQueryParams) error
 }
 
 type insuredRepository struct {
@@ -34,20 +34,20 @@ func (ir *insuredRepository) GetInsureds(insureds *[]model.Insured, birthday str
 	return nil
 }
 
-func (ir *insuredRepository) GetInsuredsWithReservation(insureds *[]model.Insured, firstName, lastName, birthday string) error {
+func (ir *insuredRepository) GetInsuredsWithReservation(insureds *[]model.Insured, queryParams *model.InsuredQueryParams) error {
 
 	db := ir.db
 
-	if firstName != "" {
-		db = db.Where("first_name_kana = ?", firstName)
+	if queryParams.FirstNameKana != "" {
+		db = db.Where("first_name_kana = ?", queryParams.FirstNameKana)
 	}
 
-	if lastName != "" {
-		db = db.Where("last_name_kana = ?", lastName)
+	if queryParams.LastNameKana != "" {
+		db = db.Where("last_name_kana = ?", queryParams.LastNameKana)
 	}
 
-	if birthday != "" {
-		db = db.Where("birthday = ?", birthday)
+	if queryParams.Birthday != "" {
+		db = db.Where("birthday = ?", queryParams.Birthday)
 	}
 
 	if err := db.Preload("Sex").Preload("Reservation.ExaminationItem").Preload("Reservation.ReservationSlot").Find(insureds).Error; err != nil {

--- a/backend/usecase/insured_usecase.go
+++ b/backend/usecase/insured_usecase.go
@@ -3,20 +3,21 @@ package usecase
 import (
 	"backend/model"
 	"backend/repository"
+	"backend/validator"
 )
 
 type IInsuredUsecase interface {
 	GetInsureds(birthday string) ([]model.InsuredResponse, error)
-	GetInsuredsWithReservation(firstName, lastName, birthday string) ([]model.InsuredWithReservationResponse, error)
+	GetInsuredsWithReservation(queryParams model.InsuredQueryParams) ([]model.InsuredWithReservationResponse, error)
 }
 
 type insuredUsecase struct {
 	ir repository.IInsuredRepository
-	// iv validator.IInsuredValidator
+	iv validator.IInsuredValidator
 }
 
-func NewInsuredUsecase(ir repository.IInsuredRepository) IInsuredUsecase {
-	return &insuredUsecase{ir}
+func NewInsuredUsecase(ir repository.IInsuredRepository, iv validator.IInsuredValidator) IInsuredUsecase {
+	return &insuredUsecase{ir, iv}
 }
 
 func (iu *insuredUsecase) GetInsureds(birthday string) ([]model.InsuredResponse, error) {
@@ -44,9 +45,14 @@ func (iu *insuredUsecase) GetInsureds(birthday string) ([]model.InsuredResponse,
 	return resInsureds, nil
 }
 
-func (iu *insuredUsecase) GetInsuredsWithReservation(firstName, lastName, birthday string) ([]model.InsuredWithReservationResponse, error) {
+func (iu *insuredUsecase) GetInsuredsWithReservation(queryParams model.InsuredQueryParams) ([]model.InsuredWithReservationResponse, error) {
+
+	if err := iu.iv.InsuredQueryParamsValidate(queryParams); err != nil {
+		return nil, err
+	}
+
 	insureds := []model.Insured{}
-	if err := iu.ir.GetInsuredsWithReservation(&insureds, firstName, lastName, birthday); err != nil {
+	if err := iu.ir.GetInsuredsWithReservation(&insureds, &queryParams); err != nil {
 		return nil, err
 	}
 

--- a/backend/validator/insured_validator.go
+++ b/backend/validator/insured_validator.go
@@ -1,0 +1,41 @@
+package validator
+
+import (
+	"backend/model"
+	"regexp"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+type IInsuredValidator interface {
+	InsuredQueryParamsValidate(queryParams model.InsuredQueryParams) error
+}
+
+type insuredValidator struct{}
+
+func NewInsuredValidator() IInsuredValidator {
+	return &insuredValidator{}
+}
+
+func (iv *insuredValidator) InsuredQueryParamsValidate(queryParams model.InsuredQueryParams) error {
+	return validation.ValidateStruct(&queryParams,
+		validation.Field(
+			&queryParams.FirstNameKana,
+			validation.RuneLength(1, 20).Error("limited max 20 char"),
+			validation.Match(regexp.MustCompile("^[ｦ-ﾟ]*$")).Error("only kana"),
+		),
+		validation.Field(
+			&queryParams.LastNameKana,
+			validation.RuneLength(1, 20).Error("limited max 20 char"),
+			validation.Match(regexp.MustCompile("^[ｦ-ﾟ]*$")).Error("only kana"),
+		),
+		validation.Field(
+			&queryParams.Birthday,
+			validation.Date("2006-01-02").Error("日付形式が不正です"),
+			validation.Date("2006-01-02").Min(time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)).RangeError("birthdayは1900-01-01以降の日付である必要があります"),
+			validation.Date("2006-01-02").Max(time.Now().UTC()).RangeError("birthdayは今日以前の日付である必要があります"),
+			validation.When(queryParams.LastNameKana == "" && queryParams.Birthday == "", validation.Required.Error("first_name_kana, last_name_kana or birthday is required")),
+		),
+	)
+}


### PR DESCRIPTION
予約管理ページでの被保険者検索用APIに以下のバリデーションを追加。

氏名
・半角カタカナのみ
・２０文字以内

生年月日
・日付形式のみ
・1900/1/1以降の日付
・今日以前の日付

氏名、生年月日のクエリが一つは必要。