### PR TITLE
Fix/update user

### DIFF
--- a/backend/repository/admin_repository.go
+++ b/backend/repository/admin_repository.go
@@ -8,8 +8,10 @@ import (
 
 type IAdminRepository interface {
 	GetAdminByUserID(admin *model.Admin, userId uint) error
+	GetAdminByUserIDUnscoped(admin *model.Admin, userId uint) error
 	CreateAdmin(admin *model.Admin) error
 	DeleteAdmin(userId uint) error
+	RestoreAdmin(admin *model.Admin) error
 }
 
 type adminRepository struct {
@@ -27,6 +29,13 @@ func (ar *adminRepository) GetAdminByUserID(admin *model.Admin, userId uint) err
 	return nil
 }
 
+func (ar *adminRepository) GetAdminByUserIDUnscoped(admin *model.Admin, userId uint) error {
+	if err := ar.db.Unscoped().Where("user_id = ?", userId).Find(admin).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
 func (ar *adminRepository) CreateAdmin(admin *model.Admin) error {
 	if err := ar.db.Create(admin).Error; err != nil {
 		return err
@@ -39,5 +48,13 @@ func (ar *adminRepository) DeleteAdmin(userId uint) error {
 	if result.Error != nil {
 		return result.Error
 	}
+	return nil
+}
+
+func (ar *adminRepository) RestoreAdmin(admin *model.Admin) error {
+	if err := ar.db.Unscoped().Model(admin).Update("deleted_at", gorm.Expr("NULL")).Error; err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/backend/repository/user_repository.go
+++ b/backend/repository/user_repository.go
@@ -46,7 +46,7 @@ func (ur *userRepository) CreateUser(user *model.User) error {
 }
 
 func (ur *userRepository) UpdateUser(user *model.User) error {
-	if err := ur.db.Save(user).Error; err != nil {
+	if err := ur.db.Model(&user).Updates(user).Error; err != nil {
 		return err
 	}
 	return nil

--- a/backend/usecase/user_usecase.go
+++ b/backend/usecase/user_usecase.go
@@ -147,9 +147,11 @@ func (uu *userUsecase) UpdateUser(userReq model.UserRequest, userId uint) (model
 	}
 
 	resUser := model.UserResponse{
-		ID:       user.ID,
-		Username: user.Username,
-		IsAdmin:  admin.ID > 0,
+		ID:        user.ID,
+		Username:  user.Username,
+		IsAdmin:   admin.ID > 0,
+		CreatedAt: time2str(user.CreatedAt),
+		UpdatedAt: time2str(user.UpdatedAt),
 	}
 
 	return resUser, nil

--- a/backend/usecase/user_usecase.go
+++ b/backend/usecase/user_usecase.go
@@ -125,19 +125,28 @@ func (uu *userUsecase) UpdateUser(userReq model.UserRequest, userId uint) (model
 	}
 
 	// Adminテーブルにレコードが存在するか確認
+	// 論理削除の場合も含めて、Adminテーブルにレコードが存在するか確認する
 
 	preAdmin := model.Admin{}
-	if err := uu.ar.GetAdminByUserID(&preAdmin, userId); err != nil {
+	if err := uu.ar.GetAdminByUserIDUnscoped(&preAdmin, userId); err != nil {
 		return model.UserResponse{}, err
 	}
 
+	IsAdminResult := false
 	admin := model.Admin{UserID: user.ID}
 	if userReq.IsAdmin { // リクエストのis_adminがtrue
 		if preAdmin.ID == 0 { // Adminテーブルにレコードが存在しない
 			if err := uu.ar.CreateAdmin(&admin); err != nil {
 				return model.UserResponse{}, err
 			}
+		} else { // Adminテーブルにレコードが存在する
+			if !preAdmin.DeletedAt.Time.IsZero() { // Adminテーブルにレコードが存在するが、論理削除されている
+				if err := uu.ar.RestoreAdmin(&preAdmin); err != nil { // 論理削除を解除する
+					return model.UserResponse{}, err
+				}
+			}
 		}
+		IsAdminResult = true
 	} else { // リクエストのis_adminがfalse
 		if preAdmin.ID > 0 { // Adminテーブルにレコードが存在する
 			if err := uu.ar.DeleteAdmin(userId); err != nil {
@@ -149,7 +158,7 @@ func (uu *userUsecase) UpdateUser(userReq model.UserRequest, userId uint) (model
 	resUser := model.UserResponse{
 		ID:        user.ID,
 		Username:  user.Username,
-		IsAdmin:   admin.ID > 0,
+		IsAdmin:   IsAdminResult,
 		CreatedAt: time2str(user.CreatedAt),
 		UpdatedAt: time2str(user.UpdatedAt),
 	}


### PR DESCRIPTION
ユーザー更新での以下問題に対応

1. 更新した時、作成日時が1-01-01になってしまう。
2. 管理者権限を削除されたユーザーにもう一度管理者権限を与えようとすると失敗する。

1.は作成日時を更新してしまっていたので、更新しないように修正。
2.は論理削除されていた場合は、該当レコードのdeleted_atをnullに更新する処理に修正。
